### PR TITLE
Add -q|quiet

### DIFF
--- a/lib/App/gist.pm
+++ b/lib/App/gist.pm
@@ -28,7 +28,8 @@ sub opt_spec {
 	return (
 		["description|d=s", "set the description for the gist"         ],
 		["update|u=s",      "update the given gist with the given file"],
-		["private|p",       "create a private gist"                    ]
+		["private|p",       "create a private gist"                    ],
+		["quiet|q",         "only output the web url"                  ]
 	);
 }
 
@@ -41,6 +42,7 @@ sub execute {
 	my $file	= $args -> [0];
 	my $description	= $opt -> {'description'};
 	my $public	= $opt -> {'private'} ? 0 : 1;
+	my $quiet	= $opt -> {'quiet'} ? 1 : 0;
 
 	my ($name, $data);
 
@@ -64,11 +66,16 @@ sub execute {
 		_edit_gist($gist, $id, $name, $data)	:
 		_create_gist($gist, $name, $data, $description, $public);
 
-	print "Gist " . $info -> {'id'} . " successfully created/modified.\n";
-	print "Web URL: " . $info -> {'html_url'} . "\n";
-	print "Public Clone URL: " . $info -> {'git_pull_url'} . "\n"
-		if $public;
-	print "Private Clone URL: " . $info -> {'git_push_url'} . "\n";
+
+	if ($quiet) {
+		print $info -> {'html_url'} . "\n";
+ 	} else {
+		print "Gist " . $info -> {'id'} . " successfully created/modified.\n";
+		print "Web URL: " . $info -> {'html_url'} . "\n";
+		print "Public Clone URL: " . $info -> {'git_pull_url'} . "\n"
+			if $public;
+		print "Private Clone URL: " . $info -> {'git_push_url'} . "\n";
+	}
 }
 
 sub _create_gist {

--- a/lib/App/gist.pm
+++ b/lib/App/gist.pm
@@ -29,7 +29,7 @@ sub opt_spec {
 		["description|d=s", "set the description for the gist"         ],
 		["update|u=s",      "update the given gist with the given file"],
 		["private|p",       "create a private gist"                    ],
-		["quiet|q",         "only output the web url"                  ]
+		["web|w",           "only output the web url"                  ]
 	);
 }
 
@@ -42,7 +42,7 @@ sub execute {
 	my $file	= $args -> [0];
 	my $description	= $opt -> {'description'};
 	my $public	= $opt -> {'private'} ? 0 : 1;
-	my $quiet	= $opt -> {'quiet'} ? 1 : 0;
+	my $web		= $opt -> {'web'} ? 1 : 0;
 
 	my ($name, $data);
 
@@ -67,7 +67,7 @@ sub execute {
 		_create_gist($gist, $name, $data, $description, $public);
 
 
-	if ($quiet) {
+	if ($web) {
 		print $info -> {'html_url'} . "\n";
  	} else {
 		print "Gist " . $info -> {'id'} . " successfully created/modified.\n";


### PR DESCRIPTION
If this is set, the output will be nothing but the web url. On Mac that lets
you do the following:

```
echo "ape" | gist -q | pbcopy
```

and end up with the url in the copy-paste buffer
