### PR TITLE
Add method to validate arguments so application does not wait for input

### DIFF
--- a/lib/App/gist.pm
+++ b/lib/App/gist.pm
@@ -56,7 +56,7 @@ sub opt_spec {
 sub validate_args {
     my ($self, $opt, $args) = @_;
 
-    $self->usage_error("Too few arguments.") unless %$opt || @$args;
+    $self->usage_error("Too few arguments.") unless %$opt || @$args || ! -t STDIN;
 } 
 
 sub execute {

--- a/lib/App/gist.pm
+++ b/lib/App/gist.pm
@@ -53,6 +53,12 @@ sub opt_spec {
 	);
 }
 
+sub validate_args {
+    my ($self, $opt, $args) = @_;
+
+    $self->usage_error("Too few arguments.") unless %$opt || @$args;
+} 
+
 sub execute {
 	my ($self, $opt, $args) = @_;
 


### PR DESCRIPTION
The application currently waits for input if there are no arguments or options given. I added a method to validate the arguments so it generates a usage statement if executed with no arguments or options. I tested the changes when reading from the command line or a pipe. I also tested with the other options and everything works as before. 

I'm not that familiar with dzil, so I didn't know the best way to add/modify tests and not change your build process.
